### PR TITLE
Fix Namespace Error

### DIFF
--- a/src/TertiaryInstitutes.php
+++ b/src/TertiaryInstitutes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Stephenjude\TertiaryInstitutes\TertiaryInstitutes;
+namespace Stephenjude\TertiaryInstitutes;
 
 use Stephenjude\TertiaryInstitutes\Services\CourseService;
 use Stephenjude\TertiaryInstitutes\Services\InstitutionService;

--- a/src/TertiaryInstitutesFacade.php
+++ b/src/TertiaryInstitutesFacade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Stephenjude\TertiaryInstitutes\TertiaryInstitutes;
+namespace Stephenjude\TertiaryInstitutes;
 
 use Illuminate\Support\Facades\Facade;
 


### PR DESCRIPTION
### Fix Namespace Error

Whoops\Exception\ErrorException  : Cannot declare class Stephenjude\TertiaryInstitutes\TertiaryInstitutes\TertiaryInstitutesFacade, because the name is already in use

  at C:\laragon\www\DeaconsOnlineAPI\vendor\stephenjude\tertiary-institutes\src\TertiaryInstitutesFacade.php:21
    17|     protected static function getFacadeAccessor()
    18|     {
    19|         return 'tertiary-institutes';
    20|     }
  > 21| }
    22|

